### PR TITLE
Fix linker issues for position-independent compilation

### DIFF
--- a/include/mbedtls/cipher_internal.h
+++ b/include/mbedtls/cipher_internal.h
@@ -139,7 +139,7 @@ typedef struct
 } mbedtls_cipher_context_psa;
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
-extern const mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
+extern mbedtls_cipher_definition_t mbedtls_cipher_definitions[];
 
 extern int mbedtls_cipher_supported[];
 

--- a/include/mbedtls/md_internal.h
+++ b/include/mbedtls/md_internal.h
@@ -58,29 +58,29 @@ struct mbedtls_md_info_t
 };
 
 #if defined(MBEDTLS_MD2_C)
-extern const mbedtls_md_info_t mbedtls_md2_info;
+extern mbedtls_md_info_t mbedtls_md2_info;
 #endif
 #if defined(MBEDTLS_MD4_C)
-extern const mbedtls_md_info_t mbedtls_md4_info;
+extern mbedtls_md_info_t mbedtls_md4_info;
 #endif
 #if defined(MBEDTLS_MD5_C)
-extern const mbedtls_md_info_t mbedtls_md5_info;
+extern mbedtls_md_info_t mbedtls_md5_info;
 #endif
 #if defined(MBEDTLS_RIPEMD160_C)
-extern const mbedtls_md_info_t mbedtls_ripemd160_info;
+extern mbedtls_md_info_t mbedtls_ripemd160_info;
 #endif
 #if defined(MBEDTLS_SHA1_C)
-extern const mbedtls_md_info_t mbedtls_sha1_info;
+extern mbedtls_md_info_t mbedtls_sha1_info;
 #endif
 #if defined(MBEDTLS_SHA256_C)
-extern const mbedtls_md_info_t mbedtls_sha224_info;
-extern const mbedtls_md_info_t mbedtls_sha256_info;
+extern mbedtls_md_info_t mbedtls_sha224_info;
+extern mbedtls_md_info_t mbedtls_sha256_info;
 #endif
 #if defined(MBEDTLS_SHA512_C)
 #if !defined(MBEDTLS_SHA512_NO_SHA384)
-extern const mbedtls_md_info_t mbedtls_sha384_info;
+extern mbedtls_md_info_t mbedtls_sha384_info;
 #endif
-extern const mbedtls_md_info_t mbedtls_sha512_info;
+extern mbedtls_md_info_t mbedtls_sha512_info;
 #endif
 
 #ifdef __cplusplus

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -117,24 +117,24 @@ typedef struct
 #endif
 
 #if defined(MBEDTLS_RSA_C)
-extern const mbedtls_pk_info_t mbedtls_rsa_info;
+extern mbedtls_pk_info_t mbedtls_rsa_info;
 #endif
 
 #if defined(MBEDTLS_ECP_C)
-extern const mbedtls_pk_info_t mbedtls_eckey_info;
-extern const mbedtls_pk_info_t mbedtls_eckeydh_info;
+extern mbedtls_pk_info_t mbedtls_eckey_info;
+extern mbedtls_pk_info_t mbedtls_eckeydh_info;
 #endif
 
 #if defined(MBEDTLS_ECDSA_C)
-extern const mbedtls_pk_info_t mbedtls_ecdsa_info;
+extern mbedtls_pk_info_t mbedtls_ecdsa_info;
 #endif
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
-extern const mbedtls_pk_info_t mbedtls_rsa_alt_info;
+extern mbedtls_pk_info_t mbedtls_rsa_alt_info;
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-extern const mbedtls_pk_info_t mbedtls_pk_opaque_info;
+extern mbedtls_pk_info_t mbedtls_pk_opaque_info;
 #endif
 
 #endif /* MBEDTLS_PK_WRAP_H */

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -2243,7 +2243,7 @@ static const mbedtls_cipher_info_t aes_256_nist_kwp_info = {
 };
 #endif /* MBEDTLS_NIST_KW_C */
 
-const mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
+mbedtls_cipher_definition_t mbedtls_cipher_definitions[] =
 {
 #if defined(MBEDTLS_AES_C)
     { MBEDTLS_CIPHER_AES_128_ECB,          &aes_128_ecb_info },

--- a/library/md.c
+++ b/library/md.c
@@ -53,7 +53,7 @@
 #endif
 
 #if defined(MBEDTLS_MD2_C)
-const mbedtls_md_info_t mbedtls_md2_info = {
+mbedtls_md_info_t mbedtls_md2_info = {
     "MD2",
     MBEDTLS_MD_MD2,
     16,
@@ -62,7 +62,7 @@ const mbedtls_md_info_t mbedtls_md2_info = {
 #endif
 
 #if defined(MBEDTLS_MD4_C)
-const mbedtls_md_info_t mbedtls_md4_info = {
+mbedtls_md_info_t mbedtls_md4_info = {
     "MD4",
     MBEDTLS_MD_MD4,
     16,
@@ -71,7 +71,7 @@ const mbedtls_md_info_t mbedtls_md4_info = {
 #endif
 
 #if defined(MBEDTLS_MD5_C)
-const mbedtls_md_info_t mbedtls_md5_info = {
+mbedtls_md_info_t mbedtls_md5_info = {
     "MD5",
     MBEDTLS_MD_MD5,
     16,
@@ -80,7 +80,7 @@ const mbedtls_md_info_t mbedtls_md5_info = {
 #endif
 
 #if defined(MBEDTLS_RIPEMD160_C)
-const mbedtls_md_info_t mbedtls_ripemd160_info = {
+mbedtls_md_info_t mbedtls_ripemd160_info = {
     "RIPEMD160",
     MBEDTLS_MD_RIPEMD160,
     20,
@@ -89,7 +89,7 @@ const mbedtls_md_info_t mbedtls_ripemd160_info = {
 #endif
 
 #if defined(MBEDTLS_SHA1_C)
-const mbedtls_md_info_t mbedtls_sha1_info = {
+mbedtls_md_info_t mbedtls_sha1_info = {
     "SHA1",
     MBEDTLS_MD_SHA1,
     20,
@@ -98,14 +98,14 @@ const mbedtls_md_info_t mbedtls_sha1_info = {
 #endif
 
 #if defined(MBEDTLS_SHA256_C)
-const mbedtls_md_info_t mbedtls_sha224_info = {
+mbedtls_md_info_t mbedtls_sha224_info = {
     "SHA224",
     MBEDTLS_MD_SHA224,
     28,
     64,
 };
 
-const mbedtls_md_info_t mbedtls_sha256_info = {
+mbedtls_md_info_t mbedtls_sha256_info = {
     "SHA256",
     MBEDTLS_MD_SHA256,
     32,
@@ -115,7 +115,7 @@ const mbedtls_md_info_t mbedtls_sha256_info = {
 
 #if defined(MBEDTLS_SHA512_C)
 #if !defined(MBEDTLS_SHA512_NO_SHA384)
-const mbedtls_md_info_t mbedtls_sha384_info = {
+mbedtls_md_info_t mbedtls_sha384_info = {
     "SHA384",
     MBEDTLS_MD_SHA384,
     48,
@@ -123,7 +123,7 @@ const mbedtls_md_info_t mbedtls_sha384_info = {
 };
 #endif
 
-const mbedtls_md_info_t mbedtls_sha512_info = {
+mbedtls_md_info_t mbedtls_sha512_info = {
     "SHA512",
     MBEDTLS_MD_SHA512,
     64,

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -188,7 +188,7 @@ static void rsa_debug( const void *ctx, mbedtls_pk_debug_item *items )
     items->value = &( ((mbedtls_rsa_context *) ctx)->E );
 }
 
-const mbedtls_pk_info_t mbedtls_rsa_info = {
+mbedtls_pk_info_t mbedtls_rsa_info = {
     MBEDTLS_PK_RSA,
     "RSA",
     rsa_get_bitlen,
@@ -410,7 +410,7 @@ static void eckey_debug( const void *ctx, mbedtls_pk_debug_item *items )
     items->value = &( ((mbedtls_ecp_keypair *) ctx)->Q );
 }
 
-const mbedtls_pk_info_t mbedtls_eckey_info = {
+mbedtls_pk_info_t mbedtls_eckey_info = {
     MBEDTLS_PK_ECKEY,
     "EC",
     eckey_get_bitlen,
@@ -447,7 +447,7 @@ static int eckeydh_can_do( mbedtls_pk_type_t type )
             type == MBEDTLS_PK_ECKEY_DH );
 }
 
-const mbedtls_pk_info_t mbedtls_eckeydh_info = {
+mbedtls_pk_info_t mbedtls_eckeydh_info = {
     MBEDTLS_PK_ECKEY_DH,
     "EC_DH",
     eckey_get_bitlen,         /* Same underlying key structure */
@@ -713,7 +713,7 @@ static void ecdsa_rs_free( void *ctx )
 }
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
-const mbedtls_pk_info_t mbedtls_ecdsa_info = {
+mbedtls_pk_info_t mbedtls_ecdsa_info = {
     MBEDTLS_PK_ECDSA,
     "ECDSA",
     eckey_get_bitlen,     /* Compatible key structures */
@@ -837,7 +837,7 @@ static void rsa_alt_free_wrap( void *ctx )
     mbedtls_free( ctx );
 }
 
-const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
+mbedtls_pk_info_t mbedtls_rsa_alt_info = {
     MBEDTLS_PK_RSA_ALT,
     "RSA-alt",
     rsa_alt_get_bitlen,
@@ -1041,7 +1041,7 @@ static int pk_opaque_sign_wrap( void *ctx, mbedtls_md_type_t md_alg,
 #endif /* !MBEDTLS_ECDSA_C */
 }
 
-const mbedtls_pk_info_t mbedtls_pk_opaque_info = {
+mbedtls_pk_info_t mbedtls_pk_opaque_info = {
     MBEDTLS_PK_OPAQUE,
     "Opaque",
     pk_opaque_get_bitlen,


### PR DESCRIPTION
when compiled with position-independent flags e.g --apcs /ropi/rwpi --lower_ropi
linker complaints about not being able to relocate constdata to other sections,
this changeset fixes this issue.

Following are few errors that the linker generates.

Error: L6248E: md.c.o(.constdata) in PI region 'ER_RO' cannot have address type relocation to .conststring in PI region 'ER_RO'.
...
Error: L6248E: pk_wrap.c.o(.constdata) in PI region 'ER_RO' cannot have address type relocation to rsa_get_bitlen in PI region 'ER_RO'.
...
Error: L6248E: cipher_wrap.c.o(.constdata) in PI region 'ER_RO' cannot have address type relocation to aes_192_ecb_info in PI region 'ER_RW'.

JIRA: https://jira.u-blox.net/browse/PGM_KM_AWS-36

Signed-off-by: Sajjad Ahmad <sajjad.ahmed@u-blox.com>